### PR TITLE
Removed unnecessary line referencing LFS struct

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -829,7 +829,6 @@ func NewContext() {
 		LFS.ContentPath = filepath.Join(AppWorkPath, LFS.ContentPath)
 	}
 
-	sec = Cfg.Section("LFS")
 	LFS.HTTPAuthExpiry = sec.Key("LFS_HTTP_AUTH_EXPIRY").MustDuration(20 * time.Minute)
 
 	if LFS.StartServer {


### PR DESCRIPTION
https://github.com/go-gitea/gitea/pull/4035#issuecomment-394286204

@ohwgiles points out that the config section should, in fact, still be in accordance with the "server" struct, which contains the "LFS" struct. I should just remove the line
```
sec = Cfg.Section("LFS")
```